### PR TITLE
Fix Mermaid chart syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ flowchart LR
   Nav --> Grid[Domain: Grid]
   Nav --> Scents[(Domain Port: IScentRepository)]
   Robot -->|state| Mission
-  Mission --> Output[\\n STDOUT lines]
+  Mission --> Output[STDOUT lines]
 ```
 
 Layering and dependencies:


### PR DESCRIPTION
Fixes the Mermaid chart rendering problem reported in #8.

The issue was caused by invalid `\\n` escape sequence in a flowchart node text that was causing a lexical error. Removed the problematic escape sequence to allow proper Mermaid rendering.

Generated with [Claude Code](https://claude.ai/code)